### PR TITLE
[OPS-5482] Change package type.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "api",
     "php"
   ],
-  "type": "application",
+  "type": "drupal-library",
   "repositories": [
     {
       "type": "composer",


### PR DESCRIPTION
Switch the package type from `application` to `drupal-library`, so that a composered Drupal will install it to the correct target directory. This should in theory not affect projects that aren't Drupal, which would keep installing into vendor anyway.

A possible alternative "fix" would be to remove the package type from composer.json altogether.